### PR TITLE
don't use react-bootstrap's Row, Col. Refs STRIPES-427

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "type": "settings",
     "displayName": "Developer",
     "route": "/developer",
-    "actionNames": ["stripesHome", "stripesAbout"],
-    "okapiInterfaces": {
-    },
+    "actionNames": [
+      "stripesHome",
+      "stripesAbout"
+    ],
+    "okapiInterfaces": {},
     "permissionSets": [
       {
         "permissionName": "module.developer.enabled",
@@ -57,7 +59,6 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react": "^15.4.2",
-    "react-bootstrap": "^0.30.7",
     "react-hotkeys": "^0.10.0",
     "react-router-dom": "^4.0.0"
   },

--- a/settings/Configuration.js
+++ b/settings/Configuration.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Row, Col } from 'react-bootstrap';
+import { Row, Col } from '@folio/stripes-components/lib/LayoutGrid';
 import Pane from '@folio/stripes-components/lib/Pane';
 import TextField from '@folio/stripes-components/lib/TextField';
 import Checkbox from '@folio/stripes-components/lib/Checkbox';


### PR DESCRIPTION
Old versions of react-bootstrap barf up the `Warning: Accessing PropTypes via the main React package is deprecated...` message. We could just upgrade, but are working to deprecate react-bootstrap anyway.