### PR TITLE
stripes-components dep consistent with stripes-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 * Use more-current stripes-components. Refs STRIPES-495.
 * Use more-current stripes-connect. Refs STRIPES-501.
 * Add save buttons to settings pages. Fixes UID-11.
-* Ignore yarn-error.log file. Refs STRIPES-517. 
+* Ignore yarn-error.log file. Refs STRIPES-517.
+* stripes-components dep consistent with stripes-core's.
 
 ## [1.3.0](https://github.com/folio-org/ui-developer/tree/v1.3.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v1.2.0...v1.3.0)

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "webpack": "1.11.0"
   },
   "dependencies": {
-    "@folio/stripes-components": "^2.0.0",
+    "@folio/stripes-components": "^3.0.0",
     "@folio/stripes-smart-components": "^1.4.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
The stripes-components dependency was out of sync with stripes-core,
which was causing funky overlaps of the settings pane where the third
column would be superimposed on the second. This probably means we have
our Pane and Paneset components in the wrong repository, or maybe that
we are managing that dependency incorrectly. In any case, the version of
stripes-components we get from stripes-core needs to be the same as the
one we depend on here. And now it is.