### PR TITLE
Clean up dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,16 +36,16 @@
   },
   "scripts": {
     "start": "stripes serve",
-    "lint": "eslint *.js settings",
+    "lint": "eslint .",
     "test": "echo 'placeholder. no tests implemented'"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^3.0.0",
+    "@folio/eslint-config-stripes": "^3.2.0",
     "@folio/stripes-cli": "^1.4.0",
     "@folio/stripes-connect": "^3.1.0",
     "@folio/stripes-core": "^2.7.0",
     "@folio/stripes-logger": "^0.0.2",
-    "babel-eslint": "^8.0.0",
+    "babel-eslint": "^9.0.0",
     "eslint": "^5.5.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -39,15 +39,17 @@
     "test": "echo 'placeholder. no tests implemented'"
   },
   "devDependencies": {
-    "babel-core": "^6.17.0",
-    "babel-eslint": "^8.0.0",
-    "babel-preset-es2015": "^6.18.0",
-    "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "babel-register": "^6.18.0",
-    "eslint": "^4.8.0",
     "@folio/eslint-config-stripes": "^3.0.0",
-    "webpack": "1.11.0"
+    "@folio/stripes-connect": "^3.1.0",
+    "@folio/stripes-core": "^2.7.0",
+    "@folio/stripes-logger": "^0.0.2",
+    "babel-eslint": "^8.0.0",
+    "eslint": "^5.5.0",
+    "react": "^16.5.0",
+    "react-dom": "^16.5.0",
+    "react-redux": "^5.0.7",
+    "redux": "^4.0.0",
+    "webpack": "^4.10.2"
   },
   "dependencies": {
     "@folio/stripes-components": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -35,11 +35,13 @@
     ]
   },
   "scripts": {
+    "start": "stripes serve",
     "lint": "eslint *.js settings",
     "test": "echo 'placeholder. no tests implemented'"
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^3.0.0",
+    "@folio/stripes-cli": "^1.4.0",
     "@folio/stripes-connect": "^3.1.0",
     "@folio/stripes-core": "^2.7.0",
     "@folio/stripes-logger": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@folio/stripes-smart-components": "^1.4.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
-    "react-hotkeys": "^0.10.0",
     "react-router-dom": "^4.0.0",
     "redux-form": "^7.0.3"
   },

--- a/settings/Configuration.js
+++ b/settings/Configuration.js
@@ -58,7 +58,11 @@ class Configuration extends React.Component {
                 name="logger.categories"
                 label="Logging categories"
               />
-              (See <a href="https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md#configuring-the-logger">the documentation</a> for available levels.)
+              (See
+              {' '}
+              <a href="https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md#configuring-the-logger">the documentation</a>
+              {' '}
+              for available levels.)
               <hr />
               <Field
                 htmlFor="2"

--- a/settings/TestHotkeys.js
+++ b/settings/TestHotkeys.js
@@ -24,8 +24,20 @@ function TestHotkeys(props) {
           When this area is focused, type:
         </p>
         <ul>
-          <li><tt>{bindings.stripesHome || '[undefined]'}</tt> to go to the Home page</li>
-          <li><tt>{bindings.stripesAbout || '[undefined]'}</tt> to go to the About page</li>
+          <li>
+            <tt>
+              {bindings.stripesHome || '[undefined]'}
+            </tt>
+            {' '}
+            to go to the Home page
+          </li>
+          <li>
+            <tt>
+              {bindings.stripesAbout || '[undefined]'}
+            </tt>
+            {' '}
+            to go to the About page
+          </li>
         </ul>
       </Pane>
     </HotKeys>

--- a/settings/TestPlugin.js
+++ b/settings/TestPlugin.js
@@ -11,7 +11,12 @@ function TestPlugin(props) {
         <Pluggable type="markdown-editor">
           <div style={{ background: 'red' }}>[Markdown editor goes here]</div>
         </Pluggable>
-        <p>To change the preferred plugin, go <Link to="/settings/organization/plugins">here</Link>.</p>
+        <p>
+          To change the preferred plugin, go
+          {' '}
+          <Link to="/settings/organization/plugins">here</Link>
+          .
+        </p>
       </div>
     </Pane>
   );


### PR DESCRIPTION
## Purpose
Removes unnecessary `babel` packages and upgrades `eslint-config-stripes`.

## Approach
A section of output from `yarn install`:
```
[4/5] 🔗  Linking dependencies...
warning " > @folio/stripes-components@3.0.10000507" has unmet peer dependency "@folio/stripes-core@^2.7.0".
warning "@folio/stripes-components > @folio/stripes-connect@3.2.100049" has unmet peer dependency "react@*".
warning "@folio/stripes-components > @folio/stripes-connect@3.2.100049" has unmet peer dependency "react-dom@*".
warning "@folio/stripes-components > downshift@2.2.2" has unmet peer dependency "react@>=0.14.9".
warning "@folio/stripes-components > prop-types-extra@1.1.0" has unmet peer dependency "react@>=0.14.0".
warning "@folio/stripes-components > @folio/stripes-react-hotkeys@1.0.10002" has unmet peer dependency "react@*".
warning "@folio/stripes-components > @folio/stripes-react-hotkeys@1.0.10002" has unmet peer dependency "react-dom@*".
warning "@folio/stripes-components > react-highlighter@0.4.3" has unmet peer dependency "react@^0.14.0 || ^15.0.0 || ^16.0.0".
warning "@folio/stripes-components > react-intl@2.4.0" has unmet peer dependency "react@^0.14.9 || ^15.0.0 || ^16.0.0".
```

To pick an example out of there, NPM identified `react@^16.3.0` from `stripes-core`, and resolves it to `16.5.0` (the latest as of Sep. 11, 2018). NPM also identified that `react-intl` has a peer dependency on `react@^0.14.9 || ^15.0.0 || ^16.0.0`. When running `npm start` (`stripes serve`) in this repo, `react` will use the version `stripes-core` requested, `^16.3.0`, which resolves to `16.5.0`. NPM then warns you that "hey, I see you have a direct dependency on `react-intl`, but you didn't tell me explicitly what version of `react` to use here." NPM is very assertively trying to guide you away from dependency anti-patterns.

[Dependencies Done Right](https://yarnpkg.com/blog/2018/04/18/dependencies-done-right/)
[Common npm mistakes](https://medium.com/@jacob.h.page/common-npm-mistakes-51bf8989079f)
[The NPM change that discusses this behavior](https://github.com/npm/npm/issues/6565)

### But doesn't this upgrade React?
No. This only adds `react` as a dev dependency to remove the NPM warnings. It does not change how `stripes` platforms consume `ui-developer`.

Because this repo doesn't have a lockfile, a `npm install` inside of it would've resolved to the same `react@16.5.0` both before and after this change.  This repo's stated peer dependency on React is `*`, which specifies that it should work on any version of React (that's probably an incorrect statement, but we can adjust the peer dependency statements later to use `>=` and `||` instead). A `stripes` platform that includes `ui-developer` but has React locked into `16.3.0` would run `ui-developer` on `16.3.0`. A fresh `stripes` platform without a lockfile would run `ui-developer` on React `16.5.0`, since that's what the `stripes-core` `react@^16.3.0` would resolve to.
