### PR TITLE
Turn on react-hot-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
+    "react-hot-loader": "^4.3.12",
     "react-router-dom": "^4.0.0",
     "redux-form": "^7.0.3"
   },

--- a/settings/index.js
+++ b/settings/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { hot } from 'react-hot-loader';
 import { Settings } from '@folio/stripes/smart-components';
 
 import Configuration from './Configuration';
@@ -31,4 +32,4 @@ class DeveloperSettings extends React.Component {
   }
 }
 
-export default DeveloperSettings;
+export default hot(module)(DeveloperSettings);


### PR DESCRIPTION
Setup for `stripes-core` took place in https://github.com/folio-org/stripes-core/pull/431.

Turns on hot reloading for this module.