### PR TITLE
support session locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-developer
 
+## 1.8.0 (IN PROGRESS)
+
+* Session locale support.
+
 ## [1.7.0](https://github.com/folio-org/ui-developer/tree/v1.7.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v1.6.0...v1.7.0)
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react-hot-loader": "^4.3.12",
+    "react-intl": "^2.8.0",
     "react-router-dom": "^4.0.0",
     "redux-form": "^7.0.3"
   },

--- a/settings/Locale.js
+++ b/settings/Locale.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+
+import {
+  Pane,
+  Button,
+  List,
+} from '@folio/stripes/components';
+
+const Locale = (props) => {
+  const locales = [
+    { value: 'ar-AR', label: 'Arabic' },
+    { value: 'zh-CN', label: 'Chinese Simplified' },
+    { value: 'da-DK', label: 'Danish' },
+    { value: 'en-GB', label: 'English - Great Britain' },
+    { value: 'en-SE', label: 'English - Sweden' },
+    { value: 'en-US', label: 'English - United States' },
+    { value: 'de-DE', label: 'German - Germany' },
+    { value: 'hu-HU', label: 'Hungarian' },
+    { value: 'it-IT', label: 'Italian - Italy' },
+    { value: 'pt-BR', label: 'Portuguese - Brazil' },
+    { value: 'pt-PT', label: 'Portuguese - Portugal' },
+    { value: 'es-ES', label: 'Spanish - Spain' },
+  ];
+
+
+  const setLocale = (locale) => {
+    if (locale) props.stripes.setLocale(locale.value);
+  };
+
+  const itemFormatter = (locale) => {
+    return <li key={locale.value}><Button onClick={() => setLocale(locale)}>{locale.label}</Button></li>;
+  };
+
+  return (
+    <Pane
+      defaultWidth="fill"
+      paneTitle="TEMPORARY Session locale"
+    >
+      <List
+        listStyle="bullets"
+        itemFormatter={itemFormatter}
+        items={locales}
+      />
+    </Pane>
+  );
+};
+
+Locale.propTypes = {
+  stripes: PropTypes.shape({
+    setLocale: PropTypes.func,
+  }).isRequired,
+};
+
+export default Locale;

--- a/settings/Locale.js
+++ b/settings/Locale.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
 
 import {
   Pane,

--- a/settings/index.js
+++ b/settings/index.js
@@ -3,6 +3,7 @@ import { hot } from 'react-hot-loader';
 import { Settings } from '@folio/stripes/smart-components';
 
 import Configuration from './Configuration';
+import Locale from './Locale';
 import TestHotkeys from './TestHotkeys';
 import Token from './Token';
 
@@ -21,6 +22,11 @@ const pages = [
     route: 'token',
     label: 'Set Token',
     component: Token,
+  },
+  {
+    route: 'locale',
+    label: 'Session locale',
+    component: Locale,
   },
 ];
 


### PR DESCRIPTION
Allow a user to change the locale in stripes only, without any
persistence. This will allow developers to check whether locale specific
settings and styles apply correctly; it is specifically _NOT_ intended
to be a user-facing setting to enable session-based preferences.