### PR TITLE
UITEN-35 use granular permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-developer
 
+## 1.10.0 (IN PROGRESS)
+
+* Use more granular permissions. UITEN-35.
+
 ## [1.9.0](https://github.com/folio-org/ui-developer/tree/v1.9.0) (2019-05-10)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v1.8.0...v1.9.0)
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,32 @@
         "displayName": "UI: Developer module is enabled"
       },
       {
-        "permissionName": "settings.developer.enabled",
+        "permissionName": "ui-developer.settings.configuration",
         "displayName": "Settings (Developer): display list of settings pages",
+        "subPermissions": [
+          "settings.enabled"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-developer.settings.hotkeys",
+        "displayName": "Settings (Developer): hot keys test",
+        "subPermissions": [
+          "settings.enabled"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-developer.settings.token",
+        "displayName": "Settings (Developer): manage JWT authentication token",
+        "subPermissions": [
+          "settings.enabled"
+        ],
+        "visible": true
+      },
+      {
+        "permissionName": "ui-developer.settings.locale",
+        "displayName": "Settings (Developer): set session locale",
         "subPermissions": [
           "settings.enabled"
         ],

--- a/settings/index.js
+++ b/settings/index.js
@@ -14,21 +14,25 @@ const pages = [
     route: 'configuration',
     label: <FormattedMessage id="ui-developer.configuration" />,
     component: Configuration,
+    perm: 'ui-developer.settings.configuration',
   },
   {
     route: 'hotkeys',
     label: <FormattedMessage id="ui-developer.hotkeys" />,
     component: TestHotkeys,
+    perm: 'ui-developer.settings.hotkeys',
   },
   {
     route: 'token',
     label: <FormattedMessage id="ui-developer.setToken" />,
     component: Token,
+    perm: 'ui-developer.settings.token',
   },
   {
     route: 'locale',
     label: <FormattedMessage id="ui-developer.sessionLocale" />,
     component: Locale,
+    perm: 'ui-developer.settings.locale',
   },
 ];
 


### PR DESCRIPTION
Instead of a single setting to determine visibility of settings items,
use per-item permissions.

Refs [UITEN-35](https://issues.folio.org/browse/UITEN-35)