### PR TITLE
migrate to actsAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0.0 (IN PROGRESS)
 
 * Migrate to `stripes` `v3.0.0` and move `react-intl` and `react-router-dom` to peerDependencies.
+* Migrate from `stripes.type` to `stripes.actsAs`
 
 ## [1.11.0](https://github.com/folio-org/ui-developer/tree/v1.11.0) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v1.10.1...v1.11.0)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=6.0.0"
   },
   "stripes": {
-    "type": "settings",
+    "actsAs": ["settings"],
     "displayName": "ui-developer.meta.title",
     "route": "/developer",
     "actionNames": [


### PR DESCRIPTION
A stripes module can be more than one type, presenting an array in
`actsAs` rather than a single string to `type`.

Refs [STCOR-148](https://issues.folio.org/browse/STCOR-148)