### PR TITLE
UID-22 correctly label permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-developer
 
+## 2.1.0 (IN PROGRESS)
+
+* Correctly label the "Settings > Developer > Configuration" permissions. Fixes UID-22.
+
 ## [2.0.0](https://github.com/folio-org/ui-developer/tree/v2.0.0.0) (2020-03-12)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v1.11.0...v2.0.0)
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       },
       {
         "permissionName": "ui-developer.settings.configuration",
-        "displayName": "Settings (Developer): display list of settings pages",
+        "displayName": "Settings (Developer): configuration",
         "subPermissions": [
           "settings.developer.enabled"
         ],


### PR DESCRIPTION
The `Settings > Developer > Configuration` permission set was misnamed
and duplicated the label for the top-level `Settings > Developer`
permission.

Fixes [UID-22](https://issues.folio.org/browse/UID-22)