### PR TITLE
STRIPES-672 update stripes, react-intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change history for ui-developer
 
-## 2.1.0 (IN PROGRESS)
+## 3.0.0 (IN PROGRESS)
 
 * Correctly label the "Settings > Developer > Configuration" permissions. Fixes UID-22.
 * Provide checkboxes for two more config settings: `showHomeLink` and `showDevInfo`. From v2.0.1.
+* Increment `stripes` to `v4.0`, `react-intl` to `v4.5`, `react-intl-safe-html` to `v2.0`. Refs STRIPES-672.
 
 ## [2.0.0](https://github.com/folio-org/ui-developer/tree/v2.0.0.0) (2020-03-12)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v1.11.0...v2.0.0)

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^5.2.0",
-    "@folio/stripes": "^3.0.0",
+    "@folio/stripes": "^4.0.0",
     "@folio/stripes-cli": "^1.4.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^6.8.0",
@@ -84,16 +84,15 @@
     "redux": "^4.0.0"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^1.0.2",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react-hot-loader": "^4.3.12",
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes": "^3.0.0",
+    "@folio/stripes": "^4.0.0",
     "react": "*",
-    "react-intl": "^2.8.0",
+    "react-intl": "^4.5.3",
     "react-router-dom": "^4.0.0"
   }
 }

--- a/src/settings/Configuration.js
+++ b/src/settings/Configuration.js
@@ -7,8 +7,6 @@ import { Checkbox, Col, Row, TextField } from '@folio/stripes/components';
 import { ConfigForm } from '@folio/stripes/smart-components';
 import { stripesShape } from '@folio/stripes/core';
 
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
-
 class Configuration extends React.Component {
   static propTypes = {
     label: PropTypes.oneOfType([
@@ -62,11 +60,14 @@ class Configuration extends React.Component {
                 label={<FormattedMessage id="ui-developer.configuration.loggingCategories" />}
               />
               (
-              <SafeHTMLMessage
+              <FormattedMessage
                 id="ui-developer.configuration.loggingDocumentationLink"
                 values={{
-                  linkHref: 'https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#configuring-the-logger',
-                  linkText: 'the documentation',
+                  a: (...chunks) => (
+                    <a href="https://github.com/folio-org/stripes/blob/master/doc/dev-guide.md#configuring-the-logger">
+                      {chunks}
+                    </a>
+                  ),
                 }}
               />
               )

--- a/translations/ui-developer/en.json
+++ b/translations/ui-developer/en.json
@@ -6,7 +6,7 @@
   "setToken": "Set token",
 
   "configuration.loggingCategories": "Logging categories",
-  "configuration.loggingDocumentationLink": "See <a href=\"{linkHref}\">{linkText}</a> for available levels.",
+  "configuration.loggingDocumentationLink": "See <a>the documentation</a> for available levels.",
   "configuration.autoLoginUsername": "Auto-login username",
   "configuration.autoLoginPassword": "Auto-login password",
   "configuration.showPermissionsInMenu": "Show permissions in user menu?",


### PR DESCRIPTION
Increment `stripes` to `v4.0`, `react-intl` to `v4.5`. Replace
`SafeHTMLMessage` with `FormattedMessage` and render-props to handle
links.

Refs [STRIPES-672](https://issues.folio.org/browse/STRIPES-672)