### PR TITLE
Remove extraneous trailing comma

### DIFF
--- a/translations/ui-developer/en.json
+++ b/translations/ui-developer/en.json
@@ -25,5 +25,5 @@
 
   "setToken.authenticationToken": "Authentication token (JWT)",
 
-  "sessionLocale.temporarySessionLocale": "TEMPORARY Session locale",
+  "sessionLocale.temporarySessionLocale": "TEMPORARY Session locale"
 }


### PR DESCRIPTION
This made `translations/ui-developer/en.json` syntactically invalid,
and made it impossible to start Stripes on a bundle including
ui-developer.