### PR TITLE
Pass options object to FormatDisplayName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Increment `@folio/stripes` to `v5`, `react-router` to `v5.2`.
 * New developer-setting page: "Okapi query" lets you, you know, query Okapi.
 * Update to react-intl v5. UID-25.
+* Fix calls to `FormatDisplayName()` to work with `react-intl`. Fixes UID-30.
 
 ## [3.1.0](https://github.com/folio-org/ui-developer/tree/v3.1.0) (IN PROGRESS)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v3.0.0...v3.1.0)

--- a/src/settings/Locale.js
+++ b/src/settings/Locale.js
@@ -51,7 +51,7 @@ const Locale = (props) => {
     // e.g. given the current locale is `ar` and the keys `ar` and `zh-CN` show:
     //    العربية / العربية
     //    الصينية (الصين) / 中文（中国）
-    locale.label = `${intl.formatDisplayName(locale.value)} / ${locale.intl.formatDisplayName(locale.value)}`;
+    locale.label = `${intl.formatDisplayName(locale.value, { type: 'language' })} / ${locale.intl.formatDisplayName(locale.value, { type: 'language' })}`;
   });
 
   const setLocale = (locale) => {


### PR DESCRIPTION
A matter of days ago, FormatJS made the `type` key required on their DisplayNameOptions... while this is great for a TS codebase and all code therein can (has to) be written to conform, the outside world - including people who might be used to the browser API - are not. This was potentially done to shore up compatibility with future versions of Chrome, but who knows?

Anyways, simple enough to appease react-intl and not have the react-stack-trace-of-death.....
