### PR TITLE
UID-28 import supported locales from @folio/stripes/core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Increment `@folio/stripes` to `v5`, `react-router` to `v5.2`.
 * New developer-setting page: "Okapi query" lets you, you know, query Okapi.
 * Update to react-intl v5. UID-25.
+* Import supported locales from `@folio/stripes/core`.
 
 ## [3.1.0](https://github.com/folio-org/ui-developer/tree/v3.1.0) (IN PROGRESS)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v3.0.0...v3.1.0)

--- a/src/settings/Locale.js
+++ b/src/settings/Locale.js
@@ -7,32 +7,11 @@ import {
   Button,
   List,
 } from '@folio/stripes/components';
+import { supportedLocales } from '@folio/stripes/core';
 
 const Locale = (props) => {
   const intl = useIntl();
-
-  const locales = [
-    { value: 'ar', label: '' },
-    { value: 'zh-CN', label: '' },
-    { value: 'zh-TW', label: '' },
-    { value: 'da-DK', label: '' },
-    { value: 'en-GB', label: '' },
-    { value: 'en-SE', label: '' },
-    { value: 'en-US', label: '' },
-    { value: 'fr-FR', label: '' },
-    { value: 'de-DE', label: '' },
-    { value: 'he', label: '' },
-    { value: 'hu-HU', label: '' },
-    { value: 'ja', label: '' },
-    { value: 'it-IT', label: '' },
-    { value: 'pt-BR', label: '' },
-    { value: 'pt-PT', label: '' },
-    { value: 'ru', label: '' },
-    { value: 'es', label: '' },
-    { value: 'es-419', label: '' },
-    { value: 'es-ES', label: '' },
-    { value: 'ur', label: '' },
-  ];
+  const locales = supportedLocales.map(l => ({ value: l, label: '' }));
 
   // This is optional but highly recommended
   // since it prevents memory leak


### PR DESCRIPTION
Use `@folio/stripes/core`'s list of supported locales instead of
maintaining a separate, local copy.

Refs [STCOR-458](https://issues.folio.org/browse/STCOR-458), [UID-28](https://issues.folio.org/browse/UID-28); replaces #162.