### PR TITLE
refactor for simplicity

### DIFF
--- a/src/settings/Locale.js
+++ b/src/settings/Locale.js
@@ -10,27 +10,29 @@ import {
 import { supportedLocales } from '@folio/stripes/core';
 
 const Locale = (props) => {
+  // intl instance with locale derived from context, i.e. the session's locale
   const intl = useIntl();
-  const locales = supportedLocales.map(l => ({ value: l, label: '' }));
 
   // This is optional but highly recommended
   // since it prevents memory leak
   const cache = createIntlCache();
 
-  locales.forEach(locale => {
-    locale.intl = createIntl({
-      locale: locale.value,
-      messages: {}
-    }, cache);
+  // iterate through the locales list to build an array of { value, label } objects
+  const locales = supportedLocales.map(l => {
+    // intl instance with locale of current iteree
+    const lIntl = createIntl({ locale: l, messages: {} }, cache);
 
-    // label contains language in current locale and in destination locale
-    // e.g. given the current locale is `en` and the keys `ar` and `zh-CN` show:
-    //     Arabic / العربية
-    //     Chinese (China) / 中文（中国）
-    // e.g. given the current locale is `ar` and the keys `ar` and `zh-CN` show:
-    //    العربية / العربية
-    //    الصينية (الصين) / 中文（中国）
-    locale.label = `${intl.formatDisplayName(locale.value, { type: 'language' })} / ${locale.intl.formatDisplayName(locale.value, { type: 'language' })}`;
+    return {
+      value: l,
+      // label contains language in context's locale and in iteree's locale
+      // e.g. given the context's locale is `en` and the keys `ar` and `zh-CN` show:
+      //     Arabic / العربية
+      //     Chinese (China) / 中文（中国）
+      // e.g. given the context's locale is `ar` and the keys `ar` and `zh-CN` show:
+      //    العربية / العربية
+      //    الصينية (الصين) / 中文（中国）
+      label: `${intl.formatDisplayName(l, { type: 'language' })} / ${lIntl.formatDisplayName(l, { type: 'language' })}`,
+    };
   });
 
   const setLocale = (locale) => {


### PR DESCRIPTION
Don't iterate through the list of supported locales twice when once will
do just fine.