### PR TITLE
correctly capitalize fOLiO

### DIFF
--- a/translations/ui-developer/en.json
+++ b/translations/ui-developer/en.json
@@ -5,7 +5,7 @@
   "hotkeys": "Hotkeys test",
   "sessionLocale": "Session locale",
   "setToken": "Set token",
-  "folioBabies": "Folio babies",
+  "folioBabies": "FOLIO babies",
   "canIUse": "I can haz endpoint?",
   "okapiPaths": "Okapi path mapper",
   "okapiConfigurationEntries": "Okapi config entries",


### PR DESCRIPTION
The branding guidelines [say so](https://wiki.folio.org/display/OUTREACH/FOLIO+Graphics+and+Branding+Resources?preview=%2F1410162%2F14451372%2FFOLIO_BrandIdentity_Guidelines_0318_FINAL.pdf): 

> The brand should always be in all caps when writing it out – FOLIO – since it is an acronym (the Future of Libraries is Open).