### PR TITLE
UID-25 actually update to react-intl v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-final-form": "^6.3.0",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.7.0",
     "react-redux": "^5.0.7",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0"
@@ -133,7 +133,7 @@
   "peerDependencies": {
     "@folio/stripes": "^5.0.0",
     "react": "*",
-    "react-intl": "^4.5.3",
+    "react-intl": "^5.7.0",
     "react-router-dom": "^5.2.0"
   }
 }


### PR DESCRIPTION
Earlier PRs, #157 and #159, _claimed_ to update to `react-intl` `v5` but
didn't actually do it. I have no idea what happened there. This PR
actually makes the update!

Refs [UID-25](https://issues.folio.org/browse/UID-25)