### PR TITLE
UID-74 recover from missing handlers attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * Add human-readable permission name to "Current permissions" list. Fixes UID-73.
+* Recover from missing `handlers` attribute in Okapi interfaces. Fixes UID-74.
 
 ## [5.0.0](https://github.com/folio-org/ui-developer/tree/v5.0.0) (2021-03-11)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v4.0.0...v5.0.0)

--- a/src/settings/CanIUse.js
+++ b/src/settings/CanIUse.js
@@ -125,7 +125,9 @@ class CanIUse extends React.Component {
   mapPathToImpl = (impl, paths) => {
     const iface = this.implToInterface(impl.id);
     if (impl.provides) {
-      impl.provides.forEach(i => {
+      // not all interfaces actually implement routes, e.g. edge-connexion
+      // so those must be filtered out
+      impl.provides.filter(i => i.handlers).forEach(i => {
         i.handlers.forEach(handler => {
           if (!paths[handler.pathPattern]) {
             paths[handler.pathPattern] = {

--- a/src/settings/OkapiPaths.js
+++ b/src/settings/OkapiPaths.js
@@ -68,7 +68,9 @@ class OkapiPaths extends React.Component {
             modules.forEach(impl => {
               const iface = this.implToInterface(impl.id);
               if (impl.provides) {
-                impl.provides.forEach(i => {
+                // not all interfaces actually implement routes, e.g. edge-connexion
+                // so those must be filtered out
+                impl.provides.filter(i => i.handlers).forEach(i => {
                   i.handlers.forEach(handler => {
                     paths[handler.pathPattern] = {
                       iface,


### PR DESCRIPTION
Not all interfaces have a `handlers` attribute, but the previous
implementation naively assumed they did, causing an NPE.

Refs [UID-74](https://issues.folio.org/browse/UID-74)