### PR TITLE
UID-75 handle AST-ified values

### DIFF
--- a/src/settings/Translations.js
+++ b/src/settings/Translations.js
@@ -4,17 +4,34 @@ import { FormattedMessage } from 'react-intl';
 import { Pane } from '@folio/stripes/components';
 
 function renderArray(a) {
+  // types gleaned from manually inspecting AST values in the console.
+  // this is totally unscientific, but seems to be accurate-ish.
+  // do you wanna know what 3-7 are? Yeah, me too.
+  const TYPES = {
+    // simple values without placeholders, e.g. foo
+    CONSTANT: 0,
+
+    // placeholders for strings, e.g. {foo}
+    PLACEHOLDER: 1,
+
+    // placeholders with types, e.g. {foo, number}
+    TYPED_PLACEHOLDER: 2,
+
+    // html elements, e.g. <strong>foo</strong>
+    HTML_ELEMENT: 8,
+  };
+
   return a.map(t => {
     let str;
     switch (t.type) {
-      case 1: // placeholders for strings, e.g. {foo}
-      case 2: // placeholders with types, e.g. {foo, number}
+      case TYPES.PLACEHOLDER:
+      case TYPES.TYPED_PLACEHOLDER:
         str = `{${t.value}}`;
         break;
-      case 8: // html elements, e.g. <strong>foo</strong>
+      case TYPES.HTML_ELEMENT:
         str = `<${t.value}>${renderArray(t.children)}</${t.value}>`;
         break;
-      case 0: // simple values without placeholders, e.g. foo
+      case TYPES.CONSTANT:
       default:
         str = t.value;
         break;
@@ -30,8 +47,8 @@ function renderArray(a) {
  *
  * @see https://formatjs.io/docs/guides/advanced-usage#pre-compiling-messages
  *
- * @param {*} t
- * @returns
+ * @param {*} t a translation value; maybe a string, maybe an array
+ * @returns string
  */
 function renderTranslation(t) {
   if (typeof t === 'string') {

--- a/src/settings/Translations.js
+++ b/src/settings/Translations.js
@@ -3,9 +3,43 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Pane } from '@folio/stripes/components';
 
+function renderArray(a) {
+  return a.map(t => {
+    let str;
+    switch (t.type) {
+      case 1: // placeholders for strings, e.g. {foo}
+      case 2: // placeholders with types, e.g. {foo, number}
+        str = `{${t.value}}`;
+        break;
+      case 8: // html elements, e.g. <strong>foo</strong>
+        str = `<${t.value}>${renderArray(t.children)}</${t.value}>`;
+        break;
+      case 0: // simple values without placeholders, e.g. foo
+      default:
+        str = t.value;
+        break;
+    }
+    return str;
+  }).join('');
+}
+
+/**
+ * Raw translation values, i.e. those from .json files, are simple strings.
+ * If the file has been transformed into an AST, the value will be an array;
+ * such values are naively un-AST-ified in a manner that seems to work so far.
+ *
+ * @see https://formatjs.io/docs/guides/advanced-usage#pre-compiling-messages
+ *
+ * @param {*} t
+ * @returns
+ */
 function renderTranslation(t) {
   if (typeof t === 'string') {
     return <b>{t}</b>;
+  }
+
+  if (Array.isArray(t)) {
+    return <b>{(t.length === 1) ? t[0].value : renderArray(t)}</b>;
   }
 
   return `[${typeof t}]`;


### PR DESCRIPTION
When a translation file has been translated to an AST, its values will
no longer be simple strings. Naively parse these AST values back to 
strings.

Refs [UID-75](https://issues.folio.org/browse/UID-75)