### PR TITLE
UID-77 check for correctly spelled permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Recover from missing `handlers` attribute in Okapi interfaces. Fixes UID-74.
 * Add page to list all currently loaded translations. Fixes UID-75.
 * Add configurable plugin-surface page. Fixes UID-78.
+* Show serialized `stripes` object. Refs UID-77.
 
 ## [5.0.0](https://github.com/folio-org/ui-developer/tree/v5.0.0) (2021-03-11)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v4.0.0...v5.0.0)

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -106,7 +106,7 @@ const pages = [
     route: 'stripes-inspector',
     labelId: 'ui-developer.stripesInspector',
     component: StripesInspector,
-    perm: 'ui-developer.settings.stripesInsepctor',
+    perm: 'ui-developer.settings.stripesInspector',
   },
 ];
 


### PR DESCRIPTION
You can't see things you can't spell. The permission that should guard
the stripes inspector is `developer.settings.stripesInspector`.

Refs [UID-77](https://issues.folio.org/browse/UID-77)