### PR TITLE
UID-79 Add "handler surface" page

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,14 @@
         "visible": true
       },
       {
+        "permissionName": "ui-developer.settings.handler-surface",
+        "displayName": "Settings (developer): handler surface for developing handlers",
+        "subPermissions": [
+          "settings.developer.enabled"
+        ],
+        "visible": true
+      },
+      {
         "permissionName": "ui-developer.settings.stripesInspector",
         "displayName": "Settings (developer): Can display the contents of the stripes object",
         "subPermissions": [

--- a/src/settings/HandlerSurface.js
+++ b/src/settings/HandlerSurface.js
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { HandlerManager } from '@folio/stripes/core';
+import { Pane } from '@folio/stripes/components';
+
+const HandlerSurface = ({ stripes }) => {
+  const [handlerEvent, setHandlerEvent] = useState('ui-agreements-extension');
+
+  return (
+    <Pane
+      defaultWidth="fill"
+      paneTitle={<FormattedMessage id="ui-developer.handler-surface" />}
+    >
+      <FormattedMessage id="ui-developer.handler-surface.event" />
+      {' '}
+      <input type="text" value={handlerEvent} onChange={(e) => setHandlerEvent(e.target.value)} />
+      <p>
+        <FormattedMessage id="ui-developer.handler-surface.forExample" values={{ handlerEvent: 'ui-agreements-extension' }} />
+      </p>
+      <hr />
+      <HandlerManager event={handlerEvent} id="handler-surface" stripes={stripes} />
+    </Pane>
+  );
+};
+
+HandlerSurface.propTypes = {
+  stripes: PropTypes.object.isRequired,
+};
+
+export default HandlerSurface;

--- a/src/settings/HandlerSurface.js
+++ b/src/settings/HandlerSurface.js
@@ -4,8 +4,13 @@ import { FormattedMessage } from 'react-intl';
 import { HandlerManager } from '@folio/stripes/core';
 import { Pane } from '@folio/stripes/components';
 
+// We need to pass a `key` prop to <HandlerManager> to force a remount
+// whenever the handlerEvent changes; otherwise we just re-render the
+// existing <HandlerManager>, which has already cached the set of
+// relevant handlers in its constructor.
+
 const HandlerSurface = ({ stripes }) => {
-  const [handlerEvent, setHandlerEvent] = useState('ui-agreements-extension');
+  const [handlerEvent, setHandlerEvent] = useState('');
 
   return (
     <Pane
@@ -19,7 +24,7 @@ const HandlerSurface = ({ stripes }) => {
         <FormattedMessage id="ui-developer.handler-surface.forExample" values={{ handlerEvent: 'ui-agreements-extension' }} />
       </p>
       <hr />
-      <HandlerManager event={handlerEvent} id="handler-surface" stripes={stripes} />
+      <HandlerManager key={handlerEvent} event={handlerEvent} id="handler-surface" stripes={stripes} />
     </Pane>
   );
 };

--- a/src/settings/PluginSurface.js
+++ b/src/settings/PluginSurface.js
@@ -4,18 +4,23 @@ import { Pluggable } from '@folio/stripes/core';
 import { Pane } from '@folio/stripes/components';
 
 const PluginSurface = () => {
-  const [pluginType, setPluginType] = useState('eusage-reports');
+  const [pluginType, setPluginType] = useState('');
 
   return (
     <Pane
       defaultWidth="fill"
       paneTitle={<FormattedMessage id="ui-developer.plugin-surface" />}
     >
-      Plugin type:
+      <FormattedMessage id="ui-developer.plugin-surface.type" />
       {' '}
       <input type="text" value={pluginType} onChange={(e) => setPluginType(e.target.value)} />
-      <h3>{`${pluginType}`}</h3>
-      <Pluggable type={pluginType} id="pluggable-surface" />
+      <p>
+        <FormattedMessage id="ui-developer.plugin-surface.forExample" values={{ pluginType: 'ui-agreements-extension' }} />
+      </p>
+      <hr />
+      <Pluggable type={pluginType} id="pluggable-surface">
+        <FormattedMessage id="ui-developer.plugin-surface.noPlugin" values={{ pluginType }} />
+      </Pluggable>
     </Pane>
   );
 };

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -107,7 +107,7 @@ const pages = [
     route: 'handler-surface',
     labelId: 'ui-developer.handler-surface',
     component: HandlerSurface,
-    // perm: 'ui-developer.settings.handler-surface',
+    perm: 'ui-developer.settings.handler-surface',
   },
   {
     route: 'stripes-inspector',

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -18,6 +18,7 @@ import OkapiQuery from './OkapiQuery';
 import Dependencies from './Dependencies';
 import Translations from './Translations';
 import PluginSurface from './PluginSurface';
+import HandlerSurface from './HandlerSurface';
 import StripesInspector from './StripesInspector';
 
 const pages = [
@@ -101,6 +102,12 @@ const pages = [
     labelId: 'ui-developer.plugin-surface',
     component: PluginSurface,
     perm: 'ui-developer.settings.plugin-surface',
+  },
+  {
+    route: 'handler-surface',
+    labelId: 'ui-developer.handler-surface',
+    component: HandlerSurface,
+    // perm: 'ui-developer.settings.handler-surface',
   },
   {
     route: 'stripes-inspector',

--- a/translations/ui-developer/en.json
+++ b/translations/ui-developer/en.json
@@ -71,6 +71,9 @@
   "stripesInspector": "Stripes inspector",
 
   "plugin-surface": "Plugin surface",
+  "plugin-surface.type": "Plugin type:",
+  "plugin-surface.forExample": "(For example, \"{pluginType}\".)",
+  "plugin-surface.noPlugin": "(No plugin of type \"{pluginType}\".)",
 
   "permission.settings.configuration": "Settings (Developer): configuration",
   "permission.settings.perms": "Settings (Developer): perms",

--- a/translations/ui-developer/en.json
+++ b/translations/ui-developer/en.json
@@ -75,6 +75,10 @@
   "plugin-surface.forExample": "(For example, \"{pluginType}\".)",
   "plugin-surface.noPlugin": "(No plugin of type \"{pluginType}\".)",
 
+  "handler-surface": "Handler surface",
+  "handler-surface.event": "Event to handle:",
+  "handler-surface.forExample": "(For example, \"{handlerEvent}\".)",
+
   "permission.settings.configuration": "Settings (Developer): configuration",
   "permission.settings.perms": "Settings (Developer): perms",
   "permission.settings.hotkeys": "Settings (Developer): hot keys test",
@@ -86,5 +90,6 @@
   "permission.settings.dependencies": "Settings (developer): Can display dependency charts",
   "permission.settings.translations": "Settings (developer): Can display list of loaded translations",
   "permission.settings.plugin-surface": "Settings (developer): plugin surface for developing plugins",
+  "permission.settings.handler-surface": "Settings (developer): handler surface for developing handlers",
   "permission.settings.stripesInspector": "Settings (developer): Can display the contents of the stripes object"
 }


### PR DESCRIPTION
**DO NOT MERGE**

This "works", but only with whatever handler-event is named as the initial state in [the `useState` call at the top of the `HandlerSurface` functional component](https://github.com/folio-org/ui-developer/blob/b1b49fca501734a86a7c5d434b26011310025dc5/src/settings/HandlerSurface.js#L8). When you change the event name interactively, the rendering does not change with it — unlike the analogous situation with the "plugin surface" page.

I think this is because [the `<HandlerManager>` component provided by stripes-core](https://github.com/folio-org/stripes-core/blob/master/src/components/HandlerManager/HandlerManager.js) consults the `event` parameter only in the constructor, deriving the set of event-handlers at construction time and not changing them on subsequent renders.

Is there an easy way that I can (without changing `<HandlerManager>`) force this new page to re-instantiate its `<HandlerManager>` component from fresh every time the event-name changes? Or is that just a confused question?