### PR TITLE
UID-86 Pluggable-surface page now supports optional data object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Display the current contents of the stripes object. Fixes UID-77.
 * Add configurable plugin-surface page. Fixes UID-78.
 * Show serialized `stripes` object. Refs UID-77.
+* Pluggable-surface page now supports optional data object. Fixes UID-86.
 
 ## [5.0.0](https://github.com/folio-org/ui-developer/tree/v5.0.0) (2021-03-11)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v4.0.0...v5.0.0)

--- a/src/settings/PluginSurface.js
+++ b/src/settings/PluginSurface.js
@@ -1,24 +1,77 @@
 import React, { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Pluggable } from '@folio/stripes/core';
-import { Pane } from '@folio/stripes/components';
+import { Pane, Row, Col } from '@folio/stripes/components';
 
 const PluginSurface = () => {
   const [pluginType, setPluginType] = useState('');
+  const [pluginData, setPluginData] = useState('');
+
+  let dataObject;
+  let dataOK = false;
+  try {
+    dataObject = JSON.parse(pluginData);
+    dataOK = true;
+  } catch (e) {
+    // Nothing to do
+  }
 
   return (
     <Pane
       defaultWidth="fill"
       paneTitle={<FormattedMessage id="ui-developer.plugin-surface" />}
     >
-      <FormattedMessage id="ui-developer.plugin-surface.type" />
-      {' '}
-      <input type="text" value={pluginType} onChange={(e) => setPluginType(e.target.value)} />
-      <p>
-        <FormattedMessage id="ui-developer.plugin-surface.forExample" values={{ pluginType: 'ui-agreements-extension' }} />
-      </p>
-      <hr />
-      <Pluggable type={pluginType} id="pluggable-surface">
+      <Row>
+        <Col xs={4}>
+          <FormattedMessage id="ui-developer.plugin-surface.type" />
+        </Col>
+        <Col xs={8}>
+          <input type="text" value={pluginType} onChange={(e) => setPluginType(e.target.value)} />
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={4} />
+        <Col xs={8}>
+          <p>
+            <FormattedMessage
+              id="ui-developer.plugin-surface.exampleType"
+              values={{
+                pluginType: 'ui-agreements-extension',
+                code: chunks => <code>{chunks}</code>,
+              }}
+            />
+          </p>
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={4}>
+          <FormattedMessage id="ui-developer.plugin-surface.data" />
+        </Col>
+        <Col xs={8}>
+          <textarea
+            value={pluginData}
+            style={{ backgroundColor: (dataOK || pluginData === '') ? 'white' : '#fcc' }}
+            onChange={(e) => setPluginData(e.target.value)}
+          />
+        </Col>
+      </Row>
+      <Row>
+        <Col xs={4} />
+        <Col xs={8}>
+          <p>
+            <FormattedMessage
+              id="ui-developer.plugin-surface.exampleData"
+              values={{
+                data: '{"op":"match-names"}',
+                code: chunks => <code>{chunks}</code>,
+              }}
+            />
+          </p>
+        </Col>
+      </Row>
+
+      <hr style={{ marginTop: '2em' }} />
+      <Pluggable type={pluginType} id="pluggable-surface" data={dataObject}>
         <FormattedMessage id="ui-developer.plugin-surface.noPlugin" values={{ pluginType }} />
       </Pluggable>
     </Pane>

--- a/translations/ui-developer/en.json
+++ b/translations/ui-developer/en.json
@@ -71,12 +71,14 @@
 
   "plugin-surface": "Plugin surface",
   "plugin-surface.type": "Plugin type:",
-  "plugin-surface.forExample": "(For example, \"{pluginType}\".)",
+  "plugin-surface.exampleType": "(Example: <code>{pluginType}</code>)",
+  "plugin-surface.data": "Data object (optional):",
+  "plugin-surface.exampleData": "(Example: <code>{data}</code>)",
   "plugin-surface.noPlugin": "(No plugin of type \"{pluginType}\".)",
 
   "handler-surface": "Handler surface",
   "handler-surface.event": "Event to handle:",
-  "handler-surface.forExample": "(For example, \"{handlerEvent}\".)",
+  "handler-surface.forExample": "(Example, \"{handlerEvent}\".)",
 
   "userLocale": "User locale",
   "userLocale.setUserLocale": "Save per-user language and localization",


### PR DESCRIPTION
When provided, this must be a valid JSON object. When entered into the
provided textarea, the background turns pink when the JSON is invalid,
and no data object is passed to the plugin; when the JSON is valid,
the background turns white again and the data object is passed.

Fixes UID-86.