### PR TITLE
UID-88 use dynamic tenant-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-developer
 
+## 5.2.0 (IN PROGRESS)
+
+* Use dynamic tenant-id. Fixes UID-88.
+
 ## [5.1.0](https://github.com/folio-org/ui-developer/tree/v5.1.0) (2021-06-17)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v5.0.0...v5.1.0)
 

--- a/src/settings/Dependencies.js
+++ b/src/settings/Dependencies.js
@@ -132,7 +132,7 @@ const Dependencies = ({ resources }) => {
 Dependencies.manifest = {
   modules: {
     type: 'okapi',
-    path: '_/proxy/tenants/diku/modules',
+    path: '_/proxy/tenants/!{stripes.okapi.tenant}/modules',
     params: { full: true },
   },
 };


### PR DESCRIPTION
Don't hard-code the tenant-id; extract it from `props.stripes.okapi`.

Refs [UID-88](https://issues.folio.org/browse/UID-88)