### PR TITLE
UID-89 support numbering-system to override locale's default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.2.0 (IN PROGRESS)
 
 * Use dynamic tenant-id. Fixes UID-88.
+* Set user numbering system independent of locale. Fixes UID-89.
 
 ## [5.1.0](https://github.com/folio-org/ui-developer/tree/v5.1.0) (2021-06-17)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v5.0.0...v5.1.0)

--- a/src/settings/UserLocale.js
+++ b/src/settings/UserLocale.js
@@ -7,6 +7,7 @@ import {
   CalloutContext,
   stripesConnect,
   supportedLocales,
+  supportedNumberingSystems,
   userLocaleConfig,
 } from '@folio/stripes/core';
 import { Button, Pane, Select, TextField, CurrencySelect } from '@folio/stripes/components';
@@ -19,6 +20,19 @@ const timeZonesOptions = timezones.map(timezone => (
   }
 ));
 
+/**
+ * localesList: list of available locales suitable for a Select
+ * label contains language in context's locale and in iteree's locale
+ * e.g. given the context's locale is `en` and the keys `ar` and `zh-CN` show:
+ *     Arabic / العربية
+ *     Chinese (China) / 中文（中国）
+ * e.g. given the context's locale is `ar` and the keys `ar` and `zh-CN` show:
+ *     العربية / العربية
+ *     الصينية (الصين) / 中文（中国）
+ *
+ * @param {object} intl react-intl object in the current context's locale
+ * @returns {array} array of {value, label} suitable for a Select
+ */
 const localesList = (intl) => {
   // This is optional but highly recommended
   // since it prevents memory leak
@@ -26,8 +40,8 @@ const localesList = (intl) => {
 
   // error handler if an intl context cannot be created,
   // i.e. if the browser is missing support for the requested locale
-  const logLocaleError = (locale) => {
-    console.warn(`monkey: ${locale}`); // eslint-disable-line
+  const logLocaleError = (e) => {
+    console.warn(e); // eslint-disable-line
   };
 
   // iterate through the locales list to build an array of { value, label } objects
@@ -42,13 +56,6 @@ const localesList = (intl) => {
 
     return {
       value: l,
-      // label contains language in context's locale and in iteree's locale
-      // e.g. given the context's locale is `en` and the keys `ar` and `zh-CN` show:
-      //     Arabic / العربية
-      //     Chinese (China) / 中文（中国）
-      // e.g. given the context's locale is `ar` and the keys `ar` and `zh-CN` show:
-      //    العربية / العربية
-      //    الصينية (الصين) / 中文（中国）
       label: `${intl.formatDisplayName(l, { type: 'language' })} / ${lIntl.formatDisplayName(l, { type: 'language' })}`,
     };
   });
@@ -56,7 +63,38 @@ const localesList = (intl) => {
   return locales;
 };
 
+/**
+ * numberingSystemsList: list of available systems, suitable for a Select
+ * label contains the name and the digits zero-nine in the given system
+ * e.g. given the system is `latn` show:
+ *     latn (0 1 2 3 4 5 6 7 8 9)
+ * e.g. given the system is `arab` show:
+ *     arab (٠ ١ ٢ ٣ ٤ ٥ ٦ ٧ ٨ ٩)
+ * More info on numbering systems:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem
 
+ * @returns {array} array of {value, label} suitable for a Select
+ */
+const numberingSystemsList = () => {
+  // This is optional but highly recommended
+  // since it prevents memory leak
+  const cache = createIntlCache();
+
+  const formats = supportedNumberingSystems.map(f => {
+    const lIntl = createIntl({
+      locale: `en-u-nu-${f}`,
+      messages: {},
+    },
+    cache);
+
+    return {
+      value: f,
+      label: `${f} (${Array.from(Array(10).keys()).map(i => lIntl.formatNumber(i)).join(' ')})`,
+    };
+  });
+
+  return formats;
+};
 
 class UserLocale extends React.Component {
   static manifest = Object.freeze({
@@ -72,9 +110,6 @@ class UserLocale extends React.Component {
       path: 'configurations/entries',
       fetch: false,
       accumulate: true,
-      PUT: {
-        path: 'configurations/entries/%{configId}',
-      }
     },
   });
 
@@ -84,6 +119,10 @@ class UserLocale extends React.Component {
     super(props);
 
     this.localesOptions = localesList(props.intl);
+    this.numberingSystemOptions = [
+      { value: '', label: '---' },
+      ...numberingSystemsList()
+    ];
     this.callout = React.createRef();
   }
 
@@ -91,7 +130,8 @@ class UserLocale extends React.Component {
     const { mutator, intl } = this.props;
     const configEntry = { ...userLocaleConfig };
 
-    const { locale, timezone, currency } = values;
+    const { currency, numberingSystem, timezone } = values;
+    let { locale } = values;
 
     // GET the user by username in order to get their UUID.
     // .then(add id to locale-settings)
@@ -114,11 +154,18 @@ class UserLocale extends React.Component {
         return mutator.localeConfig.GET({ params: { query } });
       })
       .then((res) => {
+        // A numbering system other than the locale's default
+        // may be configured with `-u-nu-SYSTEM`
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem
+        if (numberingSystem) {
+          locale = `${locale}-u-nu-${numberingSystem}`;
+        }
+
         configEntry.value = JSON.stringify({ locale, timezone, currency });
 
         if (res.configs.length) {
-          mutator.configId.replace(res.configs[0].id);
-          return mutator.localeConfig.PUT(configEntry);
+          configEntry.id = res.configs[0].id;
+          return mutator.localeConfig.PUT(configEntry, { pk: 'id' });
         } else {
           return mutator.localeConfig.POST(configEntry);
         }
@@ -161,6 +208,18 @@ class UserLocale extends React.Component {
                 placeholder="---"
                 dataOptions={this.localesOptions}
                 label={<FormattedMessage id="ui-developer.userLocale.locale" />}
+              />
+              <Field
+                component={Select}
+                id="numberingSystem"
+                name="numberingSystem"
+                dataOptions={this.numberingSystemOptions}
+                label={<FormattedMessage
+                  id="ui-developer.userLocale.numberingSystem"
+                  values={{
+                    a: chunks => <a target="new" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystem">{chunks}</a>
+                  }}
+                />}
               />
               <Field
                 component={Select}

--- a/translations/ui-developer/en.json
+++ b/translations/ui-developer/en.json
@@ -86,7 +86,8 @@
   "userLocale.locale": "Locale (for language display, date format etc.)",
   "userLocale.timeZone": "Time zone (time zone used when showing date time information)",
   "userLocale.currency": "Primary currency (for currency symbol to display)",
-  "userLocale.success": "Successfully stored locale settings for {usesrname}",
+  "userLocale.success": "Successfully stored locale settings for {username}",
+  "userLocale.numberingSystem": "Numbering system (override locale's default; <a>details</a>)",
 
   "permission.settings.configuration": "Settings (Developer): configuration",
   "permission.settings.perms": "Settings (Developer): perms",


### PR DESCRIPTION
Provide a separate setting for numbering system, allowing a user to
override their locale's default setting.

Refs [UID-89](https://issues.folio.org/browse/UIID-89)