### PR TITLE
UID-91 include necessary permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "displayName": "Settings (developer): Can display dependency charts",
         "subPermissions": [
           "settings.developer.enabled",
-          "okapi.proxy.tenants.modules.list",
+          "okapi.proxy.tenants.modules.list"
         ],
         "visible": true
       },

--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
         "permissionName": "ui-developer.settings.dependencies",
         "displayName": "Settings (developer): Can display dependency charts",
         "subPermissions": [
-          "settings.developer.enabled"
+          "settings.developer.enabled",
+          "okapi.proxy.tenants.modules.list",
         ],
         "visible": true
       },


### PR DESCRIPTION
Include necessary permissions to see the okapi dependency chart.

Refs [UID-91](https://issues.folio.org/browse/UID-91)