### PR TITLE
UID-93 define `supportedNumberingSystems` locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-developer
 
+## 5.2.2 IN PROGRESS
+
+* Define `supportedNumberingSystems` locally; it is not available from `@folio/stripes`. Refs UID-93.
+
 ## [5.2.1](https://github.com/folio-org/ui-developer/tree/v5.2.1) (2021-07-25)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v5.2.0...v5.2.1)
 

--- a/src/settings/UserLocale.js
+++ b/src/settings/UserLocale.js
@@ -7,7 +7,6 @@ import {
   CalloutContext,
   stripesConnect,
   supportedLocales,
-  supportedNumberingSystems,
   userLocaleConfig,
 } from '@folio/stripes/core';
 import { Button, Pane, Select, TextField, CurrencySelect } from '@folio/stripes/components';
@@ -62,6 +61,13 @@ const localesList = (intl) => {
 
   return locales;
 };
+
+// supported numbering systems, i.e. the systems tenants may chose
+// for numeral display
+const supportedNumberingSystems = [
+  'latn',  // Arabic (0 1 2 3 4 5 6 7 8 9)
+  'arab',  // Arabic-Hindi (٠ ١ ٢ ٣ ٤ ٥ ٦ ٧ ٨ ٩)
+];
 
 /**
  * numberingSystemsList: list of available systems, suitable for a Select


### PR DESCRIPTION
`supportedNumberingSystems` won't be exported from `@folio/stripes/core`
until `v7` so we need to define it locally here, where we are still
relying on `@folio/stripes` `v6.2`.

Refs [UID-93](https://issues.folio.org/browse/UID-93), [STRIPES-759](https://issues.folio.org/browse/STRIPES-759)