### PR TITLE
In the Permissions Inspector, show module of origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (IN PROGRESS)
 
 * Add Permissions Inspector page. Fixes UID-97.
+* In the Permissions Inspector, show which module permissions are from. Fixes UID-99.
 
 ## [6.0.0](https://github.com/folio-org/ui-developer/tree/v6.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v5.2.1...v6.0.0

--- a/src/settings/PermissionsInspector.js
+++ b/src/settings/PermissionsInspector.js
@@ -49,6 +49,17 @@ function SinglePermission({ permName, name2perm }) {
       </button>
       {expanded &&
         <span>
+          {perm.moduleName &&
+            <div style={{ margin: '0.5em 1.5em' }}>
+              <FormattedMessage
+                id="ui-developer.permissionsInspector.fromModule"
+                values={{
+                  name: perm.moduleName,
+                  code: chunks => <code>{chunks}</code>,
+                }}
+              />
+            </div>
+          }
           {perm.description &&
             <div style={{ margin: '0.5em 1.5em' }}>{perm.description}</div>
           }

--- a/src/settings/PermissionsInspector.js
+++ b/src/settings/PermissionsInspector.js
@@ -27,6 +27,7 @@ function SinglePermission({ permName, name2perm }) {
       <button
         type="button"
         style={{
+          textAlign: 'left',
           color: perm.visible ? 'black' : '#888',
         }}
         onClick={() => setExpanded(!expanded)}

--- a/src/settings/PermissionsInspector.js
+++ b/src/settings/PermissionsInspector.js
@@ -151,7 +151,7 @@ PermissionsInspector.propTypes = {
           permissionName: PropTypes.string.isRequired,
           displayName: PropTypes.string,
           description: PropTypes.string,
-          moduleName: PropTypes.string.isRequired,
+          moduleName: PropTypes.string,
           subPermissions: PropTypes.arrayOf(
             PropTypes.string.isRequired,
           ).isRequired,

--- a/translations/ui-developer/en.json
+++ b/translations/ui-developer/en.json
@@ -71,6 +71,7 @@
   "translations": "Translations",
   "stripesInspector": "Stripes inspector",
   "permissionsInspector": "Permissions inspector",
+  "permissionsInspector.fromModule": "From module <code>{name}</code>",
 
   "plugin-surface": "Plugin surface",
   "plugin-surface.type": "Plugin type:",


### PR DESCRIPTION
Fixes UID-99.

(Also, I fixed an alignment issue where there was some weird attempt to centre permission names when they were long enough not to fit on a single line.) 