### PR TITLE
Better error callouts when enabling/disabling modules

### DIFF
--- a/translations/ui-developer/en.json
+++ b/translations/ui-developer/en.json
@@ -90,6 +90,7 @@
   "okapiConsole.modules.disable.success": "Disabled module {id}",
   "okapiConsole.modules.enable.failure": "Cannot enable module {id}: {error}: {detail}",
   "okapiConsole.modules.disable.failure": "Cannot disable module {id}: {error}: {detail}",
+  "okapiConsole.modules.dependencyError": "Some dependencies would not not be satisifed",
   "okapiConsole.interfaces": "Interfaces",
 
   "plugin-surface": "Plugin surface",


### PR DESCRIPTION
* Error callouts stay around until explicitly dismissed
* In the common case that the error being reported is a violation of
  dependency constraints, the message is formatted to make the
  relevant information easier to understand.