### PR TITLE
UID-139 expose config.preserveConsole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # 8.1.0 IN PROGRESS
 
 * Handle access-control via cookies instead of `X-Okapi-Token` header. Refs UID-121.
+* Configuration: expose `preserveConsole` to toggle `console.clear()` on logout. Refs UID-139.
 
 ## [8.0.0](https://github.com/folio-org/ui-developer/tree/v8.0.0) (2023-10-19)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v7.0.0...v8.0.0)

--- a/src/settings/Configuration.js
+++ b/src/settings/Configuration.js
@@ -73,6 +73,7 @@ class Configuration extends React.Component {
           username: stripes.config.autoLogin.username,
           password: stripes.config.autoLogin.password,
         },
+        preserveConsole: stripes.config.preserveConsole || false,
       },
     };
 
@@ -164,6 +165,14 @@ class Configuration extends React.Component {
                 name="config.suppressIntlErrors"
                 id="config.suppressIntlErrors"
                 label={<FormattedMessage id="ui-developer.configuration.suppressIntlErrors" />}
+              />
+              <Field
+                htmlFor="10"
+                component={Checkbox}
+                type="checkbox"
+                name="config.preserveConsole"
+                id="config.preserveConsole"
+                label={<FormattedMessage id="ui-developer.configuration.preserveConsole" />}
               />
             </Col>
           </Row>

--- a/translations/ui-developer/en.json
+++ b/translations/ui-developer/en.json
@@ -37,6 +37,7 @@
   "configuration.showHomeLink": "Show home link in top-right menu",
   "configuration.showDevInfo": "Show developer info",
   "configuration.suppressIntlErrors": "Suppress intl errors",
+  "configuration.preserveConsole": "Preserve console on logout",
 
   "hotkeys.instructions": "When this area is focused, type:",
   "hotkeys.home": "to go to the Home page",


### PR DESCRIPTION
Expose the config value `preserveConsole` to allow toggling of that config value. It defaults to `false`, i.e. clear the console on logout.

Refs [UID-139](https://issues.folio.org/browse/UID-139)