### PR TITLE
UID-121 conservatively handle x-okapi-token

### DIFF
--- a/src/settings/CanIUse.js
+++ b/src/settings/CanIUse.js
@@ -65,11 +65,14 @@ class CanIUse extends React.Component {
   componentDidMount() {
     const { stripes } = this.props;
 
+    const token = stripes.store.getState().okapi.token;
+
     const options = {
       credentials: 'include',
       method: 'GET',
       headers: {
         'X-Okapi-Tenant': stripes.okapi.tenant,
+        ...(token && { 'X-Okapi-Token': token }),
         'Content-Type': 'application/json',
       },
     };

--- a/src/settings/OkapiPaths.js
+++ b/src/settings/OkapiPaths.js
@@ -51,12 +51,13 @@ class OkapiPaths extends React.Component {
     const { stripes } = this.props;
 
     const paths = this.state.paths;
+    const token = stripes.store.getState().okapi.token;
 
     const options = {
       method: 'GET',
       headers: {
         'X-Okapi-Tenant': stripes.okapi.tenant,
-        'X-Okapi-Token': stripes.store.getState().okapi.token,
+        ...(token && { 'X-Okapi-Token': token }),
         'Content-Type': 'application/json',
       },
     };

--- a/src/settings/Passwd.js
+++ b/src/settings/Passwd.js
@@ -102,6 +102,7 @@ class Passwd extends React.Component {
           password: values.password,
           userId,
         };
+        const token = stripes.store.getState().okapi.token;
 
         if (!res.credentialsExist) {
           return mutator.passwd.POST(credentials);
@@ -114,6 +115,7 @@ class Passwd extends React.Component {
             method: 'DELETE',
             headers: {
               'X-Okapi-Tenant': stripes.okapi.tenant,
+              ...(token && { 'X-Okapi-Token': token }),
               'Content-Type': 'application/json',
             },
           };


### PR DESCRIPTION
Handle cookie-based authorization conservatively: provide the `x-okapi-token` HTTP request header if the token is present in `stripes`; omit it otherwise.

Refs [UID-121](https://issues.folio.org/browse/UID-121)