### PR TITLE
UID-121 handle access-control without x-okapi-token header when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-developer
 
+# 8.0.1 IN PROGRESS
+
+* Handle access-control via cookies instead of `X-Okapi-Token` header. Refs UID-121.
+
 ## [8.0.0](https://github.com/folio-org/ui-developer/tree/v8.0.0) (2023-10-19)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v7.0.0...v8.0.0)
 

--- a/src/settings/CanIUse.js
+++ b/src/settings/CanIUse.js
@@ -65,11 +65,14 @@ class CanIUse extends React.Component {
   componentDidMount() {
     const { stripes } = this.props;
 
+    const token = stripes.store.getState().okapi.token;
+
     const options = {
       credentials: 'include',
       method: 'GET',
       headers: {
         'X-Okapi-Tenant': stripes.okapi.tenant,
+        ...(token && { 'X-Okapi-Token': token }),
         'Content-Type': 'application/json',
       },
     };

--- a/src/settings/CanIUse.js
+++ b/src/settings/CanIUse.js
@@ -66,10 +66,10 @@ class CanIUse extends React.Component {
     const { stripes } = this.props;
 
     const options = {
+      credentials: 'include',
       method: 'GET',
       headers: {
         'X-Okapi-Tenant': stripes.okapi.tenant,
-        'X-Okapi-Token': stripes.store.getState().okapi.token,
         'Content-Type': 'application/json',
       },
     };

--- a/src/settings/OkapiPaths.js
+++ b/src/settings/OkapiPaths.js
@@ -51,12 +51,13 @@ class OkapiPaths extends React.Component {
     const { stripes } = this.props;
 
     const paths = this.state.paths;
+    const token = stripes.store.getState().okapi.token;
 
     const options = {
       method: 'GET',
       headers: {
         'X-Okapi-Tenant': stripes.okapi.tenant,
-        'X-Okapi-Token': stripes.store.getState().okapi.token,
+        ...(token && { 'X-Okapi-Token': token }),
         'Content-Type': 'application/json',
       },
     };

--- a/src/settings/Passwd.js
+++ b/src/settings/Passwd.js
@@ -102,6 +102,7 @@ class Passwd extends React.Component {
           password: values.password,
           userId,
         };
+        const token = stripes.store.getState().okapi.token;
 
         if (!res.credentialsExist) {
           return mutator.passwd.POST(credentials);
@@ -114,6 +115,7 @@ class Passwd extends React.Component {
             method: 'DELETE',
             headers: {
               'X-Okapi-Tenant': stripes.okapi.tenant,
+              ...(token && { 'X-Okapi-Token': token }),
               'Content-Type': 'application/json',
             },
           };

--- a/src/settings/Passwd.js
+++ b/src/settings/Passwd.js
@@ -110,10 +110,10 @@ class Passwd extends React.Component {
           // a request like /foo/bar?id=someValue
           // it expects only /foo/bar/someValue
           const options = {
+            credentials: 'include',
             method: 'DELETE',
             headers: {
               'X-Okapi-Tenant': stripes.okapi.tenant,
-              'X-Okapi-Token': stripes.store.getState().okapi.token,
               'Content-Type': 'application/json',
             },
           };


### PR DESCRIPTION
Handle cookie-based authorization conservatively: provide the
`x-okapi-token` HTTP request header if the token is present in
`stripes`; omit it otherwise.

Refs UID-121, FOLIO-3627