### PR TITLE
UID-153 correctly display suppress react-intl warnings setting

### DIFF
--- a/src/settings/Configuration.js
+++ b/src/settings/Configuration.js
@@ -52,7 +52,7 @@ class Configuration extends React.Component {
         showHomeLink: stripes.config.showHomeLink || false,
         showDevInfo: stripes.config.showDevInfo || false,
         suppressIntlErrors: stripes.config.suppressIntlErrors || false,
-        suppressIntlWarnings: stripes.config.suppressIntlWarningss || false,
+        suppressIntlWarnings: stripes.config.suppressIntlWarnings || false,
         autoLogin: {
           username: stripes.config.autoLogin.username,
           password: stripes.config.autoLogin.password,


### PR DESCRIPTION
Fix the typo allowing the react-intl warnings setting to be correctly displayed. The setting was, in fact, correctly handled in stripes-core but was not correctly displayed here. 

Refs [UID-153](https://folio-org.atlassian.net/browse/UID-153), [UID-147](https://folio-org.atlassian.net/browse/UID-147)