### PR TITLE
[UID-162] Fence off ShowCapabilities behind IfInterface checks for capabilities, capability-sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Optionally suppress react-intl warnings. Refs UID-140.
 * Use type=password for auto login password field. Refs UID-147.
 * *BREAKING* Purge service-worker cruft; leverage new STCOR functions for RTR display.
+* Fence off ShowCapabilities behind IfInterface checks for capabilities, capability-sets. Refs UID-162.
 
 ## [8.0.0](https://github.com/folio-org/ui-developer/tree/v8.0.0) (2023-10-19)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v7.0.0...v8.0.0)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     ],
     "okapiInterfaces": {},
     "optionalOkapiInterfaces": {
-      "app-manager": "1.0"
+      "app-manager": "1.0",
+      "capabilities": "1.0",
+      "capability-sets": "1.0"
     },
     "permissionSets": [
       {

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -58,12 +58,6 @@ const pages = [
     component: OkapiPaths,
   },
   {
-    route: 'capabilities',
-    labelId: 'ui-developer.canIUseCapabilities',
-    component: ShowCapabilities,
-    perm: 'ui-developer.settings.configuration',
-  },
-  {
     route: 'can-i-use',
     labelId: 'ui-developer.canIUse',
     component: CanIUse,
@@ -165,6 +159,14 @@ const DeveloperSettings = (props) => {
       labelId: 'ui-developer.app-manager',
       component: AppManager,
       // perm: 'ui-developer.settings.app-manager',
+    });
+  }
+
+  if (stripes.hasInterface('capabilities') || stripes.hasInterface('capability-sets')) {
+    allPages.push({
+      route: 'capabilities',
+      labelId: 'ui-developer.canIUseCapabilities',
+      component: ShowCapabilities,
     });
   }
 


### PR DESCRIPTION
- Ensure ShowCapabilities only displays as an option when correct interfaces are present.
- Fixes [UID-162](https://folio-org.atlassian.net/browse/UID-162)