### PR TITLE
UID-107 sort locales by label, not code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 9.1.0 IN PROGRESS
 
+* Sort locales by label instead of locale-code. Refs UID-107.
+
 ## [9.0.0](https://github.com/folio-org/ui-developer/tree/v9.0.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v8.0.0...v9.0.0)
 
@@ -11,7 +13,6 @@
 * Use type=password for auto login password field. Refs UID-147.
 * *BREAKING* Purge service-worker cruft; leverage new STCOR functions for RTR display.
 * Fence off ShowCapabilities behind IfInterface checks for capabilities, capability-sets. Refs UID-162.
-* Sort locales by label instead of locale-code. Refs UID-107.
 
 ## [8.0.0](https://github.com/folio-org/ui-developer/tree/v8.0.0) (2023-10-19)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v7.0.0...v8.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Use type=password for auto login password field. Refs UID-147.
 * *BREAKING* Purge service-worker cruft; leverage new STCOR functions for RTR display.
 * Fence off ShowCapabilities behind IfInterface checks for capabilities, capability-sets. Refs UID-162.
+* Sort locales by label instead of locale-code. Refs UID-107.
 
 ## [8.0.0](https://github.com/folio-org/ui-developer/tree/v8.0.0) (2023-10-19)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v7.0.0...v8.0.0)

--- a/src/settings/SessionLocale.js
+++ b/src/settings/SessionLocale.js
@@ -35,6 +35,8 @@ const Locale = (props) => {
     };
   });
 
+  locales.sort((a, b) => a.label.localeCompare(b.label));
+
   const setLocale = (locale) => {
     if (locale) props.stripes.setLocale(locale.value);
   };

--- a/src/settings/UserLocale.js
+++ b/src/settings/UserLocale.js
@@ -59,6 +59,8 @@ const localesList = (intl) => {
     };
   });
 
+  locales.sort((a, b) => a.label.localeCompare(b.label));
+
   return locales;
 };
 


### PR DESCRIPTION
Just like it says on the tin: sort locales by label (e.g. "Chinese (China)" or "Dutch") instead of by the locale-code (e.g. `zh-cn` or `nl`) which is not displayed

Refs [UID-107](https://folio-org.atlassian.net/issues/UID-107)