### PR TITLE
UID-126 include missing permissions in settings.userLocale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Sort locales by label instead of locale-code. Refs UID-107.
 * When the Permissions Inspector encounters an undefined permission (which should never happen) it now shows that permission's true name in bold red instead of crashing. Fixes UID-183.
 * Hide "I can haz endpoint" and "Permissions inspector" if the `roles` interface is present. Refs UID-151.
+* Include missing user-related permissions in `settings.userLocale`. Refs UID-126.
 
 ## [9.0.0](https://github.com/folio-org/ui-developer/tree/v9.0.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v8.0.0...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/developer",
-  "version": "9.1.0",
+  "version": "9.1.1",
   "description": "Developer settings",
   "repository": "folio-org/ui-developer",
   "publishConfig": {
@@ -187,7 +187,8 @@
           "settings.developer.enabled",
           "configuration.entries.collection.get",
           "configuration.entries.item.post",
-          "configuration.entries.item.put"
+          "configuration.entries.item.put",
+          "users.collection.get"
         ],
         "visible": true
       },


### PR DESCRIPTION
Provide `users.collection.get` in `ui-developer.settings.userLocale`. The UI form accepts a username but configuration values are stored by user-id so we need search permission to execute a query to retrieve a record by username. 

Refs [UID-126](https://folio-org.atlassian.net/browse/UID-126)