### PR TITLE
UID-187 update react-intl to v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Hide "I can haz endpoint" and "Permissions inspector" if the `roles` interface is present. Refs UID-151.
 * Include missing user-related permissions in `settings.userLocale`. Refs UID-126.
 * Add `okapi` interface to dependencies. (We have long depended on this.) Fixes UID-184.
+* *BREAKING* Update `react-intl` to v7. Refs UID-187.
 
 ## [9.0.0](https://github.com/folio-org/ui-developer/tree/v9.0.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v8.0.0...v9.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for ui-developer
 
-## 9.1.0 IN PROGRESS
+## 10.0.0 IN PROGRESS
 
 * Sort locales by label instead of locale-code. Refs UID-107.
 * When the Permissions Inspector encounters an undefined permission (which should never happen) it now shows that permission's true name in bold red instead of crashing. Fixes UID-183.

--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
     "lint": "eslint .",
     "test": "echo 'placeholder. no tests implemented'",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-developer ./translations/ui-developer/compiled"
+    "formatjs-compile": "stripes translate compile"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",
@@ -230,14 +230,13 @@
     "@folio/eslint-config-stripes": "^7.0.0",
     "@folio/stripes": "^9.1.0",
     "@folio/stripes-cli": "^3.0.0",
-    "@formatjs/cli": "^6.1.3",
     "eslint": "^7.32.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "final-form": "^4.18.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-final-form": "^6.3.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.0"
   },
@@ -254,7 +253,7 @@
   "peerDependencies": {
     "@folio/stripes": "^9.1.0",
     "react": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/developer",
-  "version": "9.1.1",
+  "version": "10.0.0",
   "description": "Developer settings",
   "repository": "folio-org/ui-developer",
   "publishConfig": {


### PR DESCRIPTION
* update react-intl
* compile translations with stripes-cli, allowing the `@formatjs/cli` dependency to be removed

Refs [UID-187](https://folio-org.atlassian.net/browse/UID-187)