### PR TITLE
[UID-199] Add `settings.enabled` as a subpermission to all permission sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * *BREAKING* Update `@folio/stripes` to `v10`. Refs UID-186.
 * Provide application icon. Refs UID-197.
 * Remove token display; tokens are no longer user-visible. Refs UID-114.
-* Add `settings.enabled` as a subpermission to all permission sets so they can be accessed in the UI if enabled invidually. Refs UID-199.
+* Add `settings.enabled` as a subpermission to all permission sets so they can be accessed in the UI if enabled individually. Refs UID-199.
 
 ## [9.0.0](https://github.com/folio-org/ui-developer/tree/v9.0.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v8.0.0...v9.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * *BREAKING* Update `@folio/stripes` to `v10`. Refs UID-186.
 * Provide application icon. Refs UID-197.
 * Remove token display; tokens are no longer user-visible. Refs UID-114.
+* Add `settings.enabled` as a subpermission to all permission sets so they can be accessed in the UI if enabled invidually. Refs UID-199.
 
 ## [9.0.0](https://github.com/folio-org/ui-developer/tree/v9.0.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v8.0.0...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
         "permissionName": "ui-developer.settings.perms",
         "displayName": "Settings (Developer): perms",
         "subPermissions": [
-          "perms.permissions.get",
-          "settings.developer.enabled"
+          "settings.developer.enabled",
+          "perms.permissions.get"
         ],
         "visible": true
       },
@@ -83,9 +83,9 @@
         "permissionName": "ui-developer.settings.okapiConfiguration",
         "displayName": "Settings (developer): Can view tenant configuration values",
         "subPermissions": [
+          "settings.developer.enabled",
           "configuration.entries.collection.get",
-          "configuration.entries.item.get",
-          "settings.developer.enabled"
+          "configuration.entries.item.get"
         ],
         "visible": true
       },
@@ -204,13 +204,16 @@
       {
         "permissionName": "ui-developer.settings.okapiTimers",
         "displayName": "Settings (developer): Can view Okapi timers",
-        "subPermissions": [],
+        "subPermissions": [
+          "settings.developer.enabled"
+        ],
         "visible": true
       },
       {
         "permissionName": "ui-developer.settings.app-manager",
         "displayName": "Settings (developer): Can use the app manager",
         "subPermissions": [
+          "settings.developer.enabled",
           "app-manager.apps.collection.get",
           "app-manager.config.sources.all"
         ],
@@ -219,7 +222,9 @@
       {
         "permissionName": "ui-developer.settings.rtr",
         "displayName": "Settings (developer): Can dicker with token expirations in redux",
-        "subPermissions": [],
+        "subPermissions": [
+          "settings.developer.enabled"
+        ],
         "visible": true
       }
     ]


### PR DESCRIPTION
- Fulfills [UID-199](https://folio-org.atlassian.net/browse/UID-199)
- By doing this, all permission sets can be accessed in the UI if enabled individually.