### PR TITLE
UID-202: Refactor `UserLocale` component to use mod-settings API instead of mod-configuration; remove `Locale` field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change history for ui-developer
 
-## 10.0.0 IN PROGRESS
+## 11.0.0 IN PROGRESS
+
+* Add `settings.enabled` as a subpermission to all permission sets so they can be accessed in the UI if enabled individually. Refs UID-199.
+* *BREAKING* Refactor `UserLocale` component to use mod-settings API instead of mod-configuration; remove `Locale` field. Refs UID-202.
+
+## [10.0.0](https://github.com/folio-org/ui-developer/tree/v10.0.0) (2025-03-17)
+[Full Changelog](https://github.com/folio-org/ui-developer/compare/v9.0.0...v10.0.0)
 
 * Sort locales by label instead of locale-code. Refs UID-107.
 * When the Permissions Inspector encounters an undefined permission (which should never happen) it now shows that permission's true name in bold red instead of crashing. Fixes UID-183.
@@ -11,7 +17,6 @@
 * *BREAKING* Update `@folio/stripes` to `v10`. Refs UID-186.
 * Provide application icon. Refs UID-197.
 * Remove token display; tokens are no longer user-visible. Refs UID-114.
-* Add `settings.enabled` as a subpermission to all permission sets so they can be accessed in the UI if enabled individually. Refs UID-199.
 
 ## [9.0.0](https://github.com/folio-org/ui-developer/tree/v9.0.0) (2024-10-09)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v8.0.0...v9.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/developer",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "description": "Developer settings",
   "repository": "folio-org/ui-developer",
   "publishConfig": {
@@ -27,6 +27,7 @@
       }
     ],
     "okapiInterfaces": {
+      "settings": "1.0",
       "okapi": "1.9"
     },
     "optionalOkapiInterfaces": {
@@ -194,9 +195,11 @@
         "displayName": "Settings (developer): Can edit user configuration values",
         "subPermissions": [
           "settings.developer.enabled",
-          "configuration.entries.collection.get",
-          "configuration.entries.item.post",
-          "configuration.entries.item.put",
+          "mod-settings.entries.collection.get",
+          "mod-settings.entries.item.post",
+          "mod-settings.entries.item.put",
+          "mod-settings.owner.read.stripes-core.prefs.manage",
+          "mod-settings.owner.write.stripes-core.prefs.manage",
           "users.collection.get"
         ],
         "visible": true

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -1,0 +1,1 @@
+export { default as useUsers } from './useUsers';

--- a/src/queries/useUsers/index.js
+++ b/src/queries/useUsers/index.js
@@ -1,0 +1,1 @@
+export { default } from './useUsers';

--- a/src/queries/useUsers/useUsers.js
+++ b/src/queries/useUsers/useUsers.js
@@ -1,0 +1,15 @@
+import { useCallback } from 'react';
+
+import { useOkapiKy } from '@folio/stripes/core';
+
+const useUsers = ({ tenantId } = {}) => {
+  const ky = useOkapiKy({ tenant: tenantId });
+
+  const fetchUsers = useCallback((searchParams) => ky.get('users', { searchParams }).json(), [ky]);
+
+  return {
+    fetchUsers,
+  };
+};
+
+export default useUsers;


### PR DESCRIPTION
## Description
* The locale field has been removed, since it will be present in a new my-profile -> Language & localization settings.
* The mod-settings API is used in place of mod-configuration.
* Refactor `UserLocale` component to use a functional one.

## Related PRs
https://github.com/folio-org/stripes-core/pull/1628
https://github.com/folio-org/ui-myprofile/pull/251
https://github.com/folio-org/ui-tenant-settings/pull/456

## Issues
[UID-202](https://folio-org.atlassian.net/browse/UID-202)