### PR TITLE
UID-200 tolerate missing name when sorting modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * *BREAKING* Refactor `UserLocale` component to use mod-settings API instead of mod-configuration; remove `Locale` field. Refs UID-202.
 * Support longer queries in ShowCapabilities dev tool. Refs UID-201.
 * Session timezone support. Refs UID-204.
+* Tolerate missing `name` attribute when sorting module descriptors. Refs UID-200.
 
 ## [10.0.0](https://github.com/folio-org/ui-developer/tree/v10.0.0) (2025-03-17)
 [Full Changelog](https://github.com/folio-org/ui-developer/compare/v9.0.0...v10.0.0)

--- a/src/settings/Dependencies.js
+++ b/src/settings/Dependencies.js
@@ -93,7 +93,7 @@ const Dependencies = ({ resources }) => {
   const { modules } = resources;
   if (!modules.hasLoaded) return <LoadingPane />;
 
-  modules.records.sort((a, b) => a.name.localeCompare(b.name));
+  modules.records.sort((a, b) => (a.name || a.id).localeCompare(b.name || b.id));
 
   // By inspection, module type can be determined from ID. Four types:
   //      /folio_(.*)-([0-9].)*/    UI module $1, version $2
@@ -104,10 +104,10 @@ const Dependencies = ({ resources }) => {
   modules.records.forEach(module => {
     const { id } = module;
     if ((!includeUI && !includeBackend && !includeEdge && !includeOther) ||
-        (includeUI && id.startsWith('folio_')) ||
-        (includeBackend && id.startsWith('mod-')) ||
-        (includeEdge && id.startsWith('edge-')) ||
-        (includeOther && (!id.startsWith('folio_') && !id.startsWith('mod-') && !id.startsWith('edge-')))) {
+      (includeUI && id.startsWith('folio_')) ||
+      (includeBackend && id.startsWith('mod-')) ||
+      (includeEdge && id.startsWith('edge-')) ||
+      (includeOther && (!id.startsWith('folio_') && !id.startsWith('mod-') && !id.startsWith('edge-')))) {
       active.push(module);
     }
   });


### PR DESCRIPTION
When sorting module descriptors, tolerate those missing the `name` attribute by supplying the `id` instead.

Refs [UID-200](https://folio-org.atlassian.net/browse/UID-200)